### PR TITLE
Fix order of commands for compiling the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ If you want to help with development we gladly accept pull-requests. To set up t
 
 ```
 npm install -g @angular/cli
-npm install
 npm install -g --production windows-build-tools (needs to be run with administrator privileges using powershell)
+npm install
 npm start (to serve the project)
 npm run electron:windows (to build the installer for production)
 ```


### PR DESCRIPTION
Windows build tools must be installed before running npm install. 

If you run npm install first, you run into nasty errors.