### PR TITLE
Fix signalR endless connection loop

### DIFF
--- a/ExilenceClient/src/app/shared/providers/party.service.ts
+++ b/ExilenceClient/src/app/shared/providers/party.service.ts
@@ -283,17 +283,20 @@ export class PartyService implements OnDestroy {
   }
 
   initHubConnection() {
-    this.logService.log('Starting signalr connection');
-    this._hubConnection.start().then(() => {
-      console.log('Successfully established signalr connection!');
-      if (this.party !== undefined && this.currentPlayer !== undefined && this.party.name !== '') {
-        this.joinParty(this.party.name, this.currentPlayer);
-      }
-      this.reconnectAttempts = 0;
-    }).catch((err) => {
-      this.logService.log('Could not connect to signalr');
-      this.reconnect();
-    });
+    // only initiate connection, when there is no connection running
+    if (this._hubConnection.state === 0) {
+      this.logService.log('Starting signalr connection');
+      this._hubConnection.start().then(() => {
+        console.log('Successfully established signalr connection!');
+        if (this.party !== undefined && this.currentPlayer !== undefined && this.party.name !== '') {
+          this.joinParty(this.party.name, this.currentPlayer);
+        }
+        this.reconnectAttempts = 0;
+      }).catch((err) => {
+        this.logService.log('Could not connect to signalr');
+        this.reconnect();
+      });
+    }
   }
 
   reconnect() {


### PR DESCRIPTION
At following conditions, 2 reconnect cycles are run and they will run forever because one is triggering another.

_hubConnection.onclose() event
_hubConnection.start() error event

The fix will now check if hub connection is already running, before trying to start a new one.