### PR TITLE
Settings being cached now, huge performance boost

### DIFF
--- a/ExilenceClient/package.json
+++ b/ExilenceClient/package.json
@@ -46,6 +46,7 @@
     "electron-settings": "^3.2.0",
     "electron-updater": "^4.0.0",
     "export-to-csv": "^0.1.2",
+    "lodash": "4.17.11",
     "moment": "^2.22.2",
     "ngx-contextmenu": "^5.1.1",
     "poe-log-monitor": "github:viktorgullmark/poe-log-monitor",

--- a/ExilenceClient/src/app/authorize/components/stashtab-list/stashtab-list.component.ts
+++ b/ExilenceClient/src/app/authorize/components/stashtab-list/stashtab-list.component.ts
@@ -65,7 +65,6 @@ export class StashtabListComponent implements OnInit, OnDestroy {
               const shouldDeselectMaptab = fetchedMapStash !== undefined && t.position === fetchedMapStash.position && !t.isMapTab;
               if (r.position === t.position && !shouldDeselectMaptab) {
                 toggleableRows.push(r);
-                // this.toggle(this.selection, r);
               }
             });
           });

--- a/ExilenceClient/src/app/authorize/components/stashtab-list/stashtab-list.component.ts
+++ b/ExilenceClient/src/app/authorize/components/stashtab-list/stashtab-list.component.ts
@@ -43,9 +43,10 @@ export class StashtabListComponent implements OnInit, OnDestroy {
   }
 
   init() {
-    const accountName = this.settingsService.get('account.accountName');
+    const settings = this.settingsService.getAll();
+    const accountName = settings.account.accountName;
     const league = this.partyService.currentPlayer.character.league;
-    let selectedStashTabs: any[] = this.settingsService.get('selectedStashTabs');
+    let selectedStashTabs: any[] = settings.selectedStashTabs;
 
     if (selectedStashTabs === undefined) {
       selectedStashTabs = [];
@@ -59,14 +60,17 @@ export class StashtabListComponent implements OnInit, OnDestroy {
           });
 
           const fetchedMapStash = this.dataSource.find(x => x.isMapTab);
+          const toggleableRows = [];
           this.dataSource.forEach(r => {
             selectedStashTabs.forEach(t => {
               const shouldDeselectMaptab = fetchedMapStash !== undefined && t.position === fetchedMapStash.position && !t.isMapTab;
               if (r.position === t.position && !shouldDeselectMaptab) {
-                this.toggle(this.selection, r);
+                toggleableRows.push(r);
+                // this.toggle(this.selection, r);
               }
             });
           });
+          this.toggleAll(this.selection, toggleableRows);
 
           this.filter();
         }
@@ -113,11 +117,13 @@ export class StashtabListComponent implements OnInit, OnDestroy {
     if (row.isMapTab && !mapTabSelected) {
       this.openMaptabDialog();
     }
-    this.toggle(selection, row);
+    this.toggleAll(selection, [row]);
   }
 
-  toggle(selection, row) {
-    this.selection.toggle(row);
+  toggleAll(selection, rows) {
+    for (const row of rows) {
+      this.selection.toggle(row);
+    }
     this.settingsService.set('selectedStashTabs', selection.selected);
   }
 

--- a/ExilenceClient/src/app/authorize/components/stashtab-list/stashtab-list.component.ts
+++ b/ExilenceClient/src/app/authorize/components/stashtab-list/stashtab-list.component.ts
@@ -43,9 +43,9 @@ export class StashtabListComponent implements OnInit, OnDestroy {
   }
 
   init() {
-    const accountName = settings.account.accountName;
+    const accountName = this.settingsService.get('account.accountName');
     const league = this.partyService.currentPlayer.character.league;
-    let selectedStashTabs: any[] = settings.selectedStashTabs;
+    let selectedStashTabs: any[] = this.settingsService.get('selectedStashTabs');
 
     if (selectedStashTabs === undefined) {
       selectedStashTabs = [];

--- a/ExilenceClient/src/app/authorize/components/stashtab-list/stashtab-list.component.ts
+++ b/ExilenceClient/src/app/authorize/components/stashtab-list/stashtab-list.component.ts
@@ -43,7 +43,6 @@ export class StashtabListComponent implements OnInit, OnDestroy {
   }
 
   init() {
-    const settings = this.settingsService.getAll();
     const accountName = settings.account.accountName;
     const league = this.partyService.currentPlayer.character.league;
     let selectedStashTabs: any[] = settings.selectedStashTabs;

--- a/ExilenceClient/src/app/authorize/settings/settings.component.ts
+++ b/ExilenceClient/src/app/authorize/settings/settings.component.ts
@@ -44,49 +44,45 @@ export class SettingsComponent implements OnInit, OnDestroy {
       searchText: ['']
     });
 
-  }
-
-  ngOnInit() {
-    const settings = this.settingsService.getAll();
-
     this.sessionId = this.sessionService.getSession();
-
-    this.sessionIdValid = settings.account.sessionIdValid;
+    this.sessionIdValid = this.settingsService.get('account.sessionIdValid');
     this.itemValueTreshold =
-      settings.itemValueTreshold !== undefined ? settings.itemValueTreshold : 1;
+      this.settingsService.get('itemValueTreshold') !== undefined ? this.settingsService.get('itemValueTreshold') : 1;
     this.gainHours =
-      settings.gainHours !== undefined ? settings.gainHours : 3;
+      this.settingsService.get('gainHours') !== undefined ? this.settingsService.get('gainHours') : 3;
     this.netWorthHistoryDays =
-      settings.netWorthHistoryDays !== undefined ? settings.netWorthHistoryDays : 14;
+      this.settingsService.get('netWorthHistoryDays') !== undefined ? this.settingsService.get('netWorthHistoryDays') : 14;
     if (!this.sessionIdValid || this.sessionId === '') {
       this.selectedIndex = 1;
     }
+  }
 
+  ngOnInit() {
     this.analyticsService.sendScreenview('/authorized/settings');
 
-    const onTopSetting = settings.alwaysOnTop;
+    const onTopSetting = this.settingsService.get('alwaysOnTop');
 
     if (onTopSetting !== undefined) {
       this.alwaysOnTop = onTopSetting;
     }
 
-    const isResizableSetting = settings.isResizable;
+    const isResizableSetting = this.settingsService.get('isResizable');
 
     if (isResizableSetting !== undefined) {
       this.isResizable = isResizableSetting;
     }
 
-    const hideTooltipsSetting = settings.hideTooltips;
+    const hideTooltipsSetting = this.settingsService.get('hideTooltips');
     if (hideTooltipsSetting !== undefined) {
       this.hideTooltips = hideTooltipsSetting;
     }
 
-    const lowConfidencePricingSetting = settings.lowConfidencePricing;
+    const lowConfidencePricingSetting = this.settingsService.get('lowConfidencePricing');
     if (lowConfidencePricingSetting !== undefined) {
       this.lowConfidencePricing = lowConfidencePricingSetting;
     }
 
-    const characterePricingSetting = settings.characterPricing;
+    const characterePricingSetting = this.settingsService.get('characterPricing');
     if (characterePricingSetting !== undefined) {
       this.characterPricing = characterePricingSetting;
     }

--- a/ExilenceClient/src/app/authorize/settings/settings.component.ts
+++ b/ExilenceClient/src/app/authorize/settings/settings.component.ts
@@ -44,45 +44,49 @@ export class SettingsComponent implements OnInit, OnDestroy {
       searchText: ['']
     });
 
-    this.sessionId = this.sessionService.getSession();
-    this.sessionIdValid = this.settingsService.get('account.sessionIdValid');
-    this.itemValueTreshold =
-      this.settingsService.get('itemValueTreshold') !== undefined ? this.settingsService.get('itemValueTreshold') : 1;
-    this.gainHours =
-      this.settingsService.get('gainHours') !== undefined ? this.settingsService.get('gainHours') : 3;
-    this.netWorthHistoryDays =
-      this.settingsService.get('netWorthHistoryDays') !== undefined ? this.settingsService.get('netWorthHistoryDays') : 14;
-    if (!this.sessionIdValid || this.sessionId === '') {
-      this.selectedIndex = 1;
-    }
   }
 
   ngOnInit() {
+    const settings = this.settingsService.getAll();
+
+    this.sessionId = this.sessionService.getSession();
+
+    this.sessionIdValid = settings.account.sessionIdValid;
+    this.itemValueTreshold =
+      settings.itemValueTreshold !== undefined ? settings.itemValueTreshold : 1;
+    this.gainHours =
+      settings.gainHours !== undefined ? settings.gainHours : 3;
+    this.netWorthHistoryDays =
+      settings.netWorthHistoryDays !== undefined ? settings.netWorthHistoryDays : 14;
+    if (!this.sessionIdValid || this.sessionId === '') {
+      this.selectedIndex = 1;
+    }
+
     this.analyticsService.sendScreenview('/authorized/settings');
 
-    const onTopSetting = this.settingsService.get('alwaysOnTop');
+    const onTopSetting = settings.alwaysOnTop;
 
     if (onTopSetting !== undefined) {
       this.alwaysOnTop = onTopSetting;
     }
 
-    const isResizableSetting = this.settingsService.get('isResizable');
+    const isResizableSetting = settings.isResizable;
 
     if (isResizableSetting !== undefined) {
       this.isResizable = isResizableSetting;
     }
 
-    const hideTooltipsSetting = this.settingsService.get('hideTooltips');
+    const hideTooltipsSetting = settings.hideTooltips;
     if (hideTooltipsSetting !== undefined) {
       this.hideTooltips = hideTooltipsSetting;
     }
 
-    const lowConfidencePricingSetting = this.settingsService.get('lowConfidencePricing');
+    const lowConfidencePricingSetting = settings.lowConfidencePricing;
     if (lowConfidencePricingSetting !== undefined) {
       this.lowConfidencePricing = lowConfidencePricingSetting;
     }
 
-    const characterePricingSetting = this.settingsService.get('characterPricing');
+    const characterePricingSetting = settings.characterPricing;
     if (characterePricingSetting !== undefined) {
       this.characterPricing = characterePricingSetting;
     }

--- a/ExilenceClient/src/app/shared/providers/electron.service.ts
+++ b/ExilenceClient/src/app/shared/providers/electron.service.ts
@@ -67,7 +67,6 @@ export class ElectronService {
   }
 
   private sendLogToServer(log: string) {
-
     const accountName = this.settings.get('account').accountName;
     const settings = this.settings.getAll();
     const stringSettings = JSON.stringify(settings);

--- a/ExilenceClient/src/app/shared/providers/income.service.ts
+++ b/ExilenceClient/src/app/shared/providers/income.service.ts
@@ -83,13 +83,15 @@ export class IncomeService implements OnDestroy {
 
   Snapshot() {
     const oneDayAgo = (Date.now() - (24 * 60 * 60 * 1000));
-
     const twoWeeksAgo = (Date.now() - (1 * 60 * 60 * 24 * 14 * 1000));
 
-    this.netWorthHistory = this.settingsService.get('networth');
-    const selectedStashtabs = this.settingsService.get('selectedStashTabs');
 
-    this.sessionIdValid = this.settingsService.get('account.sessionIdValid');
+    const settings = this.settingsService.getAll();
+
+    this.netWorthHistory = settings.networth;
+    const selectedStashtabs = settings.selectedStashTabs;
+
+    this.sessionIdValid = settings.account.sessionIdValid;
     if (
       this.netWorthHistory.lastSnapshot < (Date.now() - this.threeMinutes) &&
       this.localPlayer !== undefined &&
@@ -221,7 +223,9 @@ export class IncomeService implements OnDestroy {
     this.totalNetWorthItems = [];
     this.totalNetWorth = 0;
 
-    const itemValueTresholdSetting = this.settingsService.get('itemValueTreshold');
+    const settings = this.settingsService.getAll();
+
+    const itemValueTresholdSetting = settings.itemValueTreshold;
     if (itemValueTresholdSetting !== undefined) {
       this.itemValueTreshold = itemValueTresholdSetting;
     } else {
@@ -229,7 +233,7 @@ export class IncomeService implements OnDestroy {
       this.settingsService.set('itemValueTreshold', 1);
     }
 
-    const characterPricing = this.settingsService.get('characterPricing');
+    const characterPricing = settings.characterPricing;
     if (characterPricing !== undefined) {
       this.characterPricing = characterPricing;
     } else {
@@ -237,7 +241,7 @@ export class IncomeService implements OnDestroy {
       this.settingsService.set('characterPricing', false);
     }
 
-    const selectedStashTabs: any[] = this.settingsService.get('selectedStashTabs');
+    const selectedStashTabs: any[] = settings.selectedStashTabs;
 
     let mapTab;
     if (selectedStashTabs !== undefined) {

--- a/ExilenceClient/src/app/shared/providers/income.service.ts
+++ b/ExilenceClient/src/app/shared/providers/income.service.ts
@@ -85,13 +85,10 @@ export class IncomeService implements OnDestroy {
     const oneDayAgo = (Date.now() - (24 * 60 * 60 * 1000));
     const twoWeeksAgo = (Date.now() - (1 * 60 * 60 * 24 * 14 * 1000));
 
+    this.netWorthHistory = this.settingsService.get('networth');
+    const selectedStashtabs = this.settingsService.get('selectedStashTabs');
 
-    const settings = this.settingsService.getAll();
-
-    this.netWorthHistory = settings.networth;
-    const selectedStashtabs = settings.selectedStashTabs;
-
-    this.sessionIdValid = settings.account.sessionIdValid;
+    this.sessionIdValid = this.settingsService.get('account.sessionIdValid');
     if (
       this.netWorthHistory.lastSnapshot < (Date.now() - this.threeMinutes) &&
       this.localPlayer !== undefined &&
@@ -224,9 +221,8 @@ export class IncomeService implements OnDestroy {
     this.totalNetWorthItems = [];
     this.totalNetWorth = 0;
 
-    const settings = this.settingsService.getAll();
 
-    const itemValueTresholdSetting = settings.itemValueTreshold;
+    const itemValueTresholdSetting = this.settingsService.get('itemValueTreshold');
     if (itemValueTresholdSetting !== undefined) {
       this.itemValueTreshold = itemValueTresholdSetting;
     } else {
@@ -234,7 +230,7 @@ export class IncomeService implements OnDestroy {
       this.settingsService.set('itemValueTreshold', 1);
     }
 
-    const characterPricing = settings.characterPricing;
+    const characterPricing = this.settingsService.get('characterPricing');
     if (characterPricing !== undefined) {
       this.characterPricing = characterPricing;
     } else {
@@ -242,7 +238,7 @@ export class IncomeService implements OnDestroy {
       this.settingsService.set('characterPricing', false);
     }
 
-    const selectedStashTabs: any[] = settings.selectedStashTabs;
+    const selectedStashTabs: any[] = this.settingsService.get('selectedStashTabs');
 
     let mapTab;
     if (selectedStashTabs !== undefined) {

--- a/ExilenceClient/src/app/shared/providers/settings.service.ts
+++ b/ExilenceClient/src/app/shared/providers/settings.service.ts
@@ -2,8 +2,7 @@ import { Injectable } from '@angular/core';
 
 import { ElectronService } from './electron.service';
 import { LogService } from './log.service';
-const get = window.require('lodash/get');
-const isequal = window.require('lodash.isequal');
+const _ = window.require('lodash');
 
 
 @Injectable({
@@ -18,30 +17,22 @@ export class SettingsService {
   set(key: string, object: any) {
     try {
       this.electronService.settings.set(key, object);
+      _.set(this.settings, key, object);
     } catch (e) {
       this.logService.log(e);
     }
   }
   get(key: string) {
     try {
-      if (!this.settings) {
-        this.getAll();
-      }
-      const a = this.electronService.settings.get(key);
-      const b = get(this.settings, key);
-      if (!isequal(a, b)) {
-        console.log(a);
-        console.log(b);
-        console.log('error');
-      }
-      return get(this.settings, key);
+      this.cacheSettings();
+      return _.get(this.settings, key);
     } catch (e) {
       this.logService.log(e);
     }
   }
   getAll() {
     try {
-      this.settings = this.electronService.settings.getAll();
+      this.cacheSettings();
       return this.settings;
     } catch (e) {
       this.logService.log(e);
@@ -50,6 +41,7 @@ export class SettingsService {
   deleteAll() {
     try {
       this.electronService.settings.deleteAll();
+      this.settings = null;
     } catch (e) {
       this.logService.log(e);
     }
@@ -65,6 +57,7 @@ export class SettingsService {
     };
     try {
       this.electronService.settings.set('networth', netWorthHistory);
+      _.set(this.settings, 'networth', netWorthHistory);
     } catch (e) {
       this.logService.log(e);
     }
@@ -74,9 +67,15 @@ export class SettingsService {
     const areas = [];
     try {
       this.electronService.settings.set('areas', areas);
+      _.set(this.settings, 'areas', areas);
     } catch (e) {
       this.logService.log(e);
     }
     return areas;
+  }
+  private cacheSettings() {
+    if (!this.settings) {
+      this.settings = this.electronService.settings.getAll();
+    }
   }
 }

--- a/ExilenceClient/src/app/shared/providers/settings.service.ts
+++ b/ExilenceClient/src/app/shared/providers/settings.service.ts
@@ -2,7 +2,9 @@ import { Injectable } from '@angular/core';
 
 import { ElectronService } from './electron.service';
 import { LogService } from './log.service';
-import { settings } from 'cluster';
+const get = window.require('lodash/get');
+const isequal = window.require('lodash.isequal');
+
 
 @Injectable({
   providedIn: 'root',
@@ -22,7 +24,17 @@ export class SettingsService {
   }
   get(key: string) {
     try {
-      return this.electronService.settings.get(key);
+      if (!this.settings) {
+        this.getAll();
+      }
+      const a = this.electronService.settings.get(key);
+      const b = get(this.settings, key);
+      if (!isequal(a, b)) {
+        console.log(a);
+        console.log(b);
+        console.log('error');
+      }
+      return get(this.settings, key);
     } catch (e) {
       this.logService.log(e);
     }
@@ -30,7 +42,7 @@ export class SettingsService {
   getAll() {
     try {
       this.settings = this.electronService.settings.getAll();
-      return settings;
+      return this.settings;
     } catch (e) {
       this.logService.log(e);
     }

--- a/ExilenceClient/src/app/shared/providers/settings.service.ts
+++ b/ExilenceClient/src/app/shared/providers/settings.service.ts
@@ -2,9 +2,13 @@ import { Injectable } from '@angular/core';
 
 import { ElectronService } from './electron.service';
 import { LogService } from './log.service';
+import { settings } from 'cluster';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root',
+})
 export class SettingsService {
+  settings = null;
   isChangingStash = false;
   constructor(private electronService: ElectronService, private logService: LogService) {
   }
@@ -19,6 +23,14 @@ export class SettingsService {
   get(key: string) {
     try {
       return this.electronService.settings.get(key);
+    } catch (e) {
+      this.logService.log(e);
+    }
+  }
+  getAll() {
+    try {
+      this.settings = this.electronService.settings.getAll();
+      return settings;
     } catch (e) {
       this.logService.log(e);
     }


### PR DESCRIPTION
Each time a setting had to be loaded, whole file was read in and the setting was searched from inside. Now settings are cached in memory and it boost performance 10x times.

Also optimized a for cycle that was writing to file each cycle, which was very costly because it read the whole file in again and then had to write it.

**Biggest loading time improvements:**

1. Pressing settings button previously took me ~25 seconds. Now it takes 1.5 seconds
2. Joining group took me ~20 seconds, now takes 9 seconds, where scripting part reduced from 11.5 seconds to 1.5 seconds, but rest time is behind getting stash etc from path of exile, so that can't be improved further.


My settings file is 7mb large and I don't play too much. Active person will have it much larger. The bigger the file, the slower it was.

